### PR TITLE
adds Gemfile & Gemfile.lock

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,3 @@
+source "https://rubygems.org"
+
+gem 'rest_client'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,12 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    netrc (0.7.7)
+    rest_client (1.7.3)
+      netrc (~> 0.7.7)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  rest_client


### PR DESCRIPTION
This adds a Gemfile & Gemfile.lock such that users can install dependencies with the following:

```
bundle install
```

Quick assessment suggests to me that the only not-built-in dependency is rest_client. Please let me know if I'm mistaken. I installed using MRI Ruby 2.1.2.
